### PR TITLE
Fix a typo

### DIFF
--- a/docs/src/priors.md
+++ b/docs/src/priors.md
@@ -66,12 +66,12 @@ end
 
 For the distribution file you must implement the following:
 ```julia
-struct new_dist <: distibution_sample
+struct new_dist <: distribution_sample
     ...
 end
 
 
-function log_likelihood!(r::AbstractArray,x::AbstractMatrix, distibution_sample::mv_gaussian , group::Int64 = -1)
+function log_likelihood!(r::AbstractArray,x::AbstractMatrix, distribution_sample::mv_gaussian , group::Int64 = -1)
      ...
     r .= (each sample log likelihood)
 end

--- a/src/distributions/multinomial_dist.jl
+++ b/src/distributions/multinomial_dist.jl
@@ -5,11 +5,11 @@ using Distributions
     multinomial_hyper(α::AbstractArray{Float32,1})
 [Dirichlet Distribution](https://en.wikipedia.org/wiki/Dirichlet_distribution)
 """
-struct multinomial_dist <: distibution_sample
+struct multinomial_dist <: distribution_sample
     α::AbstractArray{Float32,1}
 end
 
 
-function log_likelihood!(r::AbstractArray,x::AbstractArray, distibution_sample::multinomial_dist , group::Int64 = -1)
-    r .= (distibution_sample.α' * x)[1,:]
+function log_likelihood!(r::AbstractArray,x::AbstractArray, distribution_sample::multinomial_dist , group::Int64 = -1)
+    r .= (distribution_sample.α' * x)[1,:]
 end

--- a/src/distributions/mv_gaussian.jl
+++ b/src/distributions/mv_gaussian.jl
@@ -9,7 +9,7 @@ using Distributions
         invChol::UpperTriangular)
 [Multivariate Normal Distribution](https://en.wikipedia.org/wiki/Multivariate_normal_distribution)
 """
-struct mv_gaussian <: distibution_sample
+struct mv_gaussian <: distribution_sample
     μ::AbstractArray{Float32,1}
     Σ::AbstractArray{Float32,2}
     invΣ::AbstractArray{Float32,2}
@@ -18,8 +18,8 @@ struct mv_gaussian <: distibution_sample
 end
 
 
-function log_likelihood!(r::AbstractArray,x::AbstractMatrix, distibution_sample::mv_gaussian , group::Int64 = -1)
-     z = x .- distibution_sample.μ
-    dcolwise_dot!(r,z, distibution_sample.invΣ * z)
-    r .= -((length(distibution_sample.Σ) * Float32(log(2π)) + distibution_sample.logdetΣ)/2) .-r/2
+function log_likelihood!(r::AbstractArray,x::AbstractMatrix, distribution_sample::mv_gaussian , group::Int64 = -1)
+     z = x .- distribution_sample.μ
+    dcolwise_dot!(r,z, distribution_sample.invΣ * z)
+    r .= -((length(distribution_sample.Σ) * Float32(log(2π)) + distribution_sample.logdetΣ)/2) .-r/2
 end

--- a/src/ds.jl
+++ b/src/ds.jl
@@ -1,7 +1,7 @@
 abstract type distribution_hyper_params end
 #Suff statistics must contain N which is the number of points associated with the cluster
 abstract type sufficient_statistics end
-abstract type distibution_sample end
+abstract type distribution_sample end
 import Base.copy
 
 struct model_hyper_params
@@ -12,7 +12,7 @@ end
 
 mutable struct cluster_parameters
     hyperparams::distribution_hyper_params
-    distribution::distibution_sample
+    distribution::distribution_sample
     suff_statistics::sufficient_statistics
     posterior_hyperparams::distribution_hyper_params
 end
@@ -26,7 +26,7 @@ mutable struct splittable_cluster_params
     logsublikelihood_hist::AbstractArray{Float32,1}
 end
 
-mutable struct thin_cluster_params{T <: distibution_sample}
+mutable struct thin_cluster_params{T <: distribution_sample}
     cluster_dist::T
     l_dist::T
     r_dist::T


### PR DESCRIPTION
I believe `distibution_sample` should be `distribution_sample` (although, nicely, this was consistent across the four files in which it appears).

This commit renames the variable in those four files.

It passed the existing unit tests in `run_tests.jl` on my machine.